### PR TITLE
Links always present

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Block.multiformats.add(dagPB)
 
 async function run () {
   const b1 = Block.encoder({
-    Data: new TextEncoder().encode('Some data as a string')
+    Data: new TextEncoder().encode('Some data as a string'),
+    Links: []
   }, 'dag-pb')
 
   // also possible if `prepare()` is extracted, see API details in README
@@ -55,7 +56,7 @@ const { CID } = multiformats
 const { prepare } = dagPB(multiformats)
 
 console.log(prepare({ Data: 'some data' }))
-// ->{ Data: Uint8Array(9) [115, 111, 109, 101, 32, 100,  97, 116, 97] }
+// ->{ Data: Uint8Array(9) [115, 111, 109, 101, 32, 100,  97, 116, 97], Links: [] }
 console.log(prepare({ Links: [CID.from('bafkqabiaaebagba')] }))
 // -> { Links: [ { Hash: CID(bafkqabiaaebagba) } ] }
 
@@ -69,7 +70,7 @@ Some features of `prepare()`:
 * Strings are converted to `{ Data: bytes }` (as are `Uint8Array`s)
 * Multiple ways of finding CIDs in the `Links` array are attempted, including interpreting the whole link element as a CID, reading a `Uint8Array` as a CID
 * Ensuring that properties are of the correct type (link `Name` is a `string` and `Tsize` is a `number`)
-* Empty `Links` arrays are omitted
+* `Links` array is always present, even if empty
 * `Links` array is properly sorted
 
 ## License

--- a/example.js
+++ b/example.js
@@ -5,7 +5,8 @@ Block.multiformats.add(dagPB)
 
 async function run () {
   const b1 = Block.encoder({
-    Data: new TextEncoder().encode('Some data as a string')
+    Data: new TextEncoder().encode('Some data as a string'),
+    Links: []
   }, 'dag-pb')
 
   // also possible if `prepare()` is extracted, see API details in README

--- a/index.js
+++ b/index.js
@@ -100,6 +100,8 @@ function create (multiformats) {
     if (node.Links && Array.isArray(node.Links) && node.Links.length) {
       pbn.Links = node.Links.map(asLink)
       pbn.Links.sort(linkComparator)
+    } else {
+      pbn.Links = []
     }
 
     return pbn
@@ -130,16 +132,8 @@ function create (multiformats) {
       throw new TypeError('Invalid DAG-PB form (Data must be a Uint8Array)')
     }
 
-    if (node.Links === undefined) {
-      return
-    }
-
     if (!Array.isArray(node.Links)) {
       throw new TypeError('Invalid DAG-PB form (Links must be an array)')
-    }
-
-    if (!node.Links.length) {
-      throw new TypeError('Invalid DAG-PB form (empty Links array must be omitted)')
     }
 
     for (let i = 0; i < node.Links.length; i++) {

--- a/pb-decode.js
+++ b/pb-decode.js
@@ -109,7 +109,7 @@ function decodeLink (bytes) {
 function decodeNode (bytes) {
   const l = bytes.length
   let index = 0
-  let links
+  const links = []
   let data
 
   while (index < l) {
@@ -133,9 +133,6 @@ function decodeNode (bytes) {
 
       let byts
       ;[byts, index] = decodeBytes(bytes, index)
-      if (!links) {
-        links = []
-      }
       links.push(decodeLink(byts))
     } else {
       throw new Error(`protobuf: (PBNode) invalid fieldNumber, expected 1 or 2, got ${fieldNum}`)
@@ -151,9 +148,7 @@ function decodeNode (bytes) {
   if (data) {
     node.Data = data
   }
-  if (links) {
-    node.Links = links
-  }
+  node.Links = links
   return node
 }
 

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -30,7 +30,7 @@ function linkCidsToStrings (links) {
 describe('Basics', () => {
   it('prepare & encode an empty node', () => {
     const prepared = prepare({})
-    assert.deepEqual(prepared, {})
+    assert.deepEqual(prepared, { Links: [] })
     const result = encode(prepared)
     assert.instanceOf(result, Uint8Array)
     assert.strictEqual(result.length, 0)
@@ -39,7 +39,7 @@ describe('Basics', () => {
   it('prepare & encode a node with data', () => {
     const data = Uint8Array.from([0, 1, 2, 3, 4])
     const prepared = prepare({ Data: data })
-    assert.deepEqual(prepared, { Data: data })
+    assert.deepEqual(prepared, { Data: data, Links: [] })
     const result = encode(prepared)
     assert.instanceOf(result, Uint8Array)
 
@@ -77,7 +77,7 @@ describe('Basics', () => {
 
   it('ignore invalid properties when preparing', () => {
     const prepared = prepare({ foo: 'bar' })
-    assert.deepEqual(prepared, {})
+    assert.deepEqual(prepared, { Links: [] })
     const result = encode(prepared)
     assert.strictEqual(result.length, 0)
   })
@@ -85,7 +85,7 @@ describe('Basics', () => {
   it('prepare & create a node with string data', () => {
     const data = 'some data'
     const prepared = prepare({ Data: data })
-    assert.deepEqual(prepared, { Data: new TextEncoder().encode(data) })
+    assert.deepEqual(prepared, { Data: new TextEncoder().encode(data), Links: [] })
     const serialized = encode(prepared)
     const deserialized = decode(serialized)
     assert.deepEqual(deserialized.Data, new TextEncoder().encode('some data'))
@@ -94,7 +94,7 @@ describe('Basics', () => {
   it('prepare & create a node with bare string', () => {
     const data = 'some data'
     const prepared = prepare(data)
-    assert.deepEqual(prepared, { Data: new TextEncoder().encode(data) })
+    assert.deepEqual(prepared, { Data: new TextEncoder().encode(data), Links: [] })
     const serialized = encode(prepared)
     const deserialized = decode(serialized)
     assert.deepEqual(deserialized.Data, new TextEncoder().encode('some data'))
@@ -220,22 +220,22 @@ describe('Basics', () => {
   it('prepare & create a node with bytes only', () => {
     const node = new TextEncoder().encode('hello')
     const reconstituted = decode(encode(prepare(node)))
-    assert.deepEqual(reconstituted, { Data: new TextEncoder().encode('hello') })
+    assert.deepEqual(reconstituted, { Data: new TextEncoder().encode('hello'), Links: [] })
   })
 
   it('prepare & create an empty node', () => {
     const node = new Uint8Array(0)
     const prepared = prepare(node)
-    assert.deepEqual(prepared, { Data: new Uint8Array(0) })
+    assert.deepEqual(prepared, { Data: new Uint8Array(0), Links: [] })
     const reconstituted = decode(encode(prepared))
-    assert.deepEqual(reconstituted, { Data: new Uint8Array(0) })
+    assert.deepEqual(reconstituted, { Data: new Uint8Array(0), Links: [] })
   })
 
   it('prepare & create an empty node from object', () => {
     const prepared = prepare({})
-    assert.deepEqual(prepared, {})
+    assert.deepEqual(prepared, { Links: [] })
     const reconstituted = decode(encode(prepared))
-    assert.deepEqual(reconstituted, {})
+    assert.deepEqual(reconstituted, { Links: [] })
   })
 
   it('fail to prepare & create a node with other data types', () => {

--- a/test/test-compat.js
+++ b/test/test-compat.js
@@ -42,56 +42,57 @@ function verifyRoundTrip (testCase, bypass) {
 describe('Compatibility', () => {
   it('empty', () => {
     verifyRoundTrip({
-      node: {},
+      node: { Links: [] },
       expectedBytes: '',
-      expectedForm: '{}'
+      expectedForm: `{
+  "Links": []
+}`
     })
   })
 
   it('Data zero', () => {
     verifyRoundTrip({
-      node: { Data: new Uint8Array(0) },
+      node: { Data: new Uint8Array(0), Links: [] },
       expectedBytes: '0a00',
       expectedForm: `{
-  "Data": ""
+  "Data": "",
+  "Links": []
 }`
     })
   })
 
   it('Data some', () => {
     verifyRoundTrip({
-      node: { Data: Uint8Array.from([0, 1, 2, 3, 4]) },
+      node: { Data: Uint8Array.from([0, 1, 2, 3, 4]), Links: [] },
       expectedBytes: '0a050001020304',
       expectedForm: `{
-  "Data": "0001020304"
+  "Data": "0001020304",
+  "Links": []
 }`
     })
   })
 
-  // this is excluded from the spec, it must be undefined
   it('Links zero', () => {
     const testCase = {
       node: { Links: [] },
       expectedBytes: '',
-      expectedForm: '{}'
+      expectedForm: `{
+  "Links": []
+}`
     }
-    assert.throws(() => verifyRoundTrip(testCase), /Links/)
-    // bypass straight to encode and it should verify the bytes
-    verifyRoundTrip(testCase, true)
+    verifyRoundTrip(testCase)
   })
 
-  // this is excluded from the spec, it must be undefined
   it('Data some Links zero', () => {
     const testCase = {
       node: { Data: Uint8Array.from([0, 1, 2, 3, 4]), Links: [] },
       expectedBytes: '0a050001020304',
       expectedForm: `{
-  "Data": "0001020304"
+  "Data": "0001020304",
+  "Links": []
 }`
     }
-    assert.throws(() => verifyRoundTrip(testCase), /Links/)
-    // bypass straight to encode and it should verify the bytes
-    verifyRoundTrip(testCase, true)
+    verifyRoundTrip(testCase)
   })
 
   it('Links empty', () => {

--- a/test/test-forms.js
+++ b/test/test-forms.js
@@ -22,9 +22,9 @@ describe('Forms (Data Model)', () => {
       assert.instanceOf(byts, Uint8Array)
     }
 
-    doesntThrow({})
+    doesntThrow({ Links: [] })
 
-    doesntThrow({ Data: Uint8Array.from([1, 2, 3]) })
+    doesntThrow({ Data: Uint8Array.from([1, 2, 3]), Links: [] })
     doesntThrow({
       Links: [
         { Hash: acid },
@@ -53,21 +53,20 @@ describe('Forms (Data Model)', () => {
       throws(bad)
     }
 
+    throws({})
     throws({ Data: null, Links: null })
-    throws({ Data: null })
+    throws({ Data: null, Links: [] })
     throws({ Links: null })
 
-    // empty links array not allowed, should be null
-    throws({ Links: [] })
     // empty link
     throws({ Links: [{}] })
 
-    throws({ Hash: acid, extraneous: true })
+    throws({ Data: acid.bytes, extraneous: true })
     throws({ Links: [{ Hash: acid, extraneous: true }] })
 
     // bad Data forms
     for (const bad of [true, false, 0, 101, -101, 'blip', Infinity, Symbol.for('boop'), []]) {
-      throws({ Data: bad })
+      throws({ Data: bad, Links: [] })
     }
 
     // bad Link array forms


### PR DESCRIPTION
This makes `Links` mandatory, even when empty. Having `prepare()` makes this bearable. I think being convinced by a "cardinality" argument means I'm being infected with @warpfork brain.

Ref: https://github.com/ipld/specs/pull/297#discussion_r494338322

Summary: an empty `Links` is indistinguishable from an absent `Links` in the PB form, instead of adding 3 states: absent, empty, >0 entries, we have just 2 by removing the absent state. It's always there, you don't even need to check for its existence when looking into it.