### PR TITLE
convert to new-new js-multiformats

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An implementation of the [DAG-PB spec](https://github.com/ipld/specs/blob/master
 ```js
 import CID from 'multiformats/cid'
 import { sha256 } from 'multiformats/hashes/sha2'
-import dagPB from '@ipld/dag-pb'
+import * as dagPB from '@ipld/dag-pb'
 
 async function run () {
   const bytes = dagPB.encode({

--- a/example-prepare.js
+++ b/example-prepare.js
@@ -1,9 +1,7 @@
-import multiformats from 'multiformats/basics'
-import dagPB from '@ipld/dag-pb'
-const { CID } = multiformats
-const { prepare } = dagPB(multiformats)
+import CID from 'multiformats/cid'
+import { prepare } from '@ipld/dag-pb'
 
 console.log(prepare({ Data: 'some data' }))
 // ->{ Data: Uint8Array(9) [115, 111, 109, 101, 32, 100,  97, 116, 97] }
-console.log(prepare({ Links: [CID.from('bafkqabiaaebagba')] }))
+console.log(prepare({ Links: [CID.parse('bafkqabiaaebagba')] }))
 // -> { Links: [ { Hash: CID(bafkqabiaaebagba) } ] }

--- a/example.js
+++ b/example.js
@@ -1,26 +1,23 @@
-import Block from '@ipld/block/defaults'
+import CID from 'multiformats/cid'
+import { sha256 } from 'multiformats/hashes/sha2'
 import dagPB from '@ipld/dag-pb'
 
-Block.multiformats.add(dagPB)
-
 async function run () {
-  const b1 = Block.encoder({
+  const bytes = dagPB.encode({
     Data: new TextEncoder().encode('Some data as a string'),
     Links: []
-  }, 'dag-pb')
+  })
 
-  // also possible if `prepare()` is extracted, see API details in README
-  // const b1 = Block.encoder(prepare('Some data as a string'), 'dag-pb')
-  // const b1 = Block.encoder(prepare(new TextEncoder().encode('Some data as a string')), 'dag-pb')
+  // also possible if you `import dagPB, { prepare } from '@ipld/dag-pb'`
+  // const bytes = dagPB.encode(prepare('Some data as a string'))
+  // const bytes = dagPB.encode(prepare(new TextEncoder().encode('Some data as a string')))
 
-  const cid = await b1.cid()
-  const bytes = b1.encode()
+  const hash = await sha256.digest(bytes)
+  const cid = CID.create(1, dagPB.code, hash)
 
-  console.log(cid, '=>', Block.multiformats.bytes.toHex(bytes))
+  console.log(cid, '=>', Buffer.from(bytes).toString('hex'))
 
-  const b2 = Block.decoder(bytes, 'dag-pb')
-  // or: const b2 = Block.create(bytes, cid)
-  const decoded = b2.decode()
+  const decoded = dagPB.decode(bytes)
 
   console.log(decoded)
   console.log(`decoded "Data": ${new TextDecoder().decode(decoded.Data)}`)

--- a/example.js
+++ b/example.js
@@ -1,6 +1,6 @@
 import CID from 'multiformats/cid'
 import { sha256 } from 'multiformats/hashes/sha2'
-import dagPB from '@ipld/dag-pb'
+import * as dagPB from '@ipld/dag-pb'
 
 async function run () {
   const bytes = dagPB.encode({

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-import { codec } from 'multiformats/codecs/codec'
 import CID from 'multiformats/cid'
 import decodeNode from './pb-decode.js'
 import encodeNode from './pb-encode.js'
@@ -232,5 +231,4 @@ function decode (bytes) {
   return node
 }
 
-export default codec({ name, code, encode, decode })
-export { prepare, validate }
+export { name, code, encode, decode, prepare, validate }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+import { codec } from 'multiformats/codecs/codec'
+import CID from 'multiformats/cid'
 import decodeNode from './pb-decode.js'
 import encodeNode from './pb-encode.js'
 
@@ -34,197 +36,201 @@ function hasOnlyProperties (node, properties) {
   return !Object.keys(node).some((p) => !properties.includes(p))
 }
 
-function create (multiformats) {
-  const { CID, bytes } = multiformats
-
-  const asLink = (link) => {
-    if (typeof link.asCID === 'object') {
-      const Hash = CID.asCID(link)
-      if (!Hash) {
-        throw new TypeError('Invalid DAG-PB form')
-      }
-      return { Hash }
-    }
-
-    if (typeof link !== 'object' || Array.isArray(link)) {
+function asLink (link) {
+  if (typeof link.asCID === 'object') {
+    const Hash = CID.asCID(link)
+    if (!Hash) {
       throw new TypeError('Invalid DAG-PB form')
     }
-
-    const pbl = {}
-
-    if (link.Hash) {
-      let cid
-      try {
-        cid = CID.from(link.Hash)
-      } catch (e) {}
-
-      if (cid) {
-        pbl.Hash = cid
-      }
-    }
-
-    if (!pbl.Hash) {
-      throw new TypeError('Invalid DAG-PB form')
-    }
-
-    if (typeof link.Name === 'string') {
-      pbl.Name = link.Name
-    }
-
-    if (typeof link.Tsize === 'number') {
-      pbl.Tsize = link.Tsize
-    }
-
-    return pbl
+    return { Hash }
   }
 
-  const prepare = (node) => {
-    if (node instanceof Uint8Array || typeof node === 'string') {
-      node = { Data: node }
-    }
-
-    if (typeof node !== 'object' || Array.isArray(node)) {
-      throw new TypeError('Invalid DAG-PB form')
-    }
-
-    const pbn = {}
-
-    if (node.Data) {
-      if (typeof node.Data === 'string') {
-        pbn.Data = textEncoder.encode(node.Data)
-      } else if (node.Data instanceof Uint8Array) {
-        pbn.Data = node.Data
-      }
-    }
-
-    if (node.Links && Array.isArray(node.Links) && node.Links.length) {
-      pbn.Links = node.Links.map(asLink)
-      pbn.Links.sort(linkComparator)
-    } else {
-      pbn.Links = []
-    }
-
-    return pbn
+  if (typeof link !== 'object' || Array.isArray(link)) {
+    throw new TypeError('Invalid DAG-PB form')
   }
 
-  const validate = (node) => {
-    /*
-    type PBLink struct {
-      Hash optional Link
-      Name optional String
-      Tsize optional Int
+  const pbl = {}
+
+  if (link.Hash) {
+    let cid = CID.asCID(link.Hash)
+    try {
+      if (!cid) {
+        if (typeof link.Hash === 'string') {
+          cid = CID.parse(link.Hash)
+        } else if (link.Hash instanceof Uint8Array) {
+          cid = CID.decode(link.Hash)
+        }
+      }
+    } catch (e) {
+      throw new TypeError(`Invalid DAG-PB form: ${e.message}`)
     }
 
-    type PBNode struct {
-      Links [PBLink]
-      Data optional Bytes
-    }
-    */
-    if (!node || typeof node !== 'object' || Array.isArray(node)) {
-      throw new TypeError('Invalid DAG-PB form')
-    }
-
-    if (!hasOnlyProperties(node, pbNodeProperties)) {
-      throw new TypeError('Invalid DAG-PB form (extraneous properties)')
-    }
-
-    if (node.Data !== undefined && !(node.Data instanceof Uint8Array)) {
-      throw new TypeError('Invalid DAG-PB form (Data must be a Uint8Array)')
-    }
-
-    if (!Array.isArray(node.Links)) {
-      throw new TypeError('Invalid DAG-PB form (Links must be an array)')
-    }
-
-    for (let i = 0; i < node.Links.length; i++) {
-      const link = node.Links[i]
-      if (!link || typeof link !== 'object' || Array.isArray(link)) {
-        throw new TypeError('Invalid DAG-PB form (bad link object)')
-      }
-
-      if (!hasOnlyProperties(link, pbLinkProperties)) {
-        throw new TypeError('Invalid DAG-PB form (extraneous properties on link object)')
-      }
-
-      if (!link.Hash) {
-        throw new TypeError('Invalid DAG-PB form (link must have a Hash)')
-      }
-
-      if (link.Hash.asCID !== link.Hash) {
-        throw new TypeError('Invalid DAG-PB form (link Hash must be a CID)')
-      }
-
-      if (link.Name !== undefined && typeof link.Name !== 'string') {
-        throw new TypeError('Invalid DAG-PB form (link Name must be a string)')
-      }
-
-      if (link.Tsize !== undefined && (typeof link.Tsize !== 'number' || link.Tsize % 1 !== 0)) {
-        throw new TypeError('Invalid DAG-PB form (link Tsize must be an integer)')
-      }
-
-      if (i > 0 && linkComparator(link, node.Links[i - 1]) === -1) {
-        throw new TypeError('Invalid DAG-PB form (links must be sort by Name bytes)')
-      }
+    if (cid) {
+      pbl.Hash = cid
     }
   }
 
-  const encode = (node) => {
-    validate(node)
-    const pbn = {}
-    if (node.Links) {
-      pbn.Links = node.Links.map((l) => {
-        const link = {}
-        if (l.Hash) {
-          link.Hash = l.Hash.bytes // cid -> bytes
-        }
-        if (l.Name !== undefined) {
-          link.Name = l.Name
-        }
-        if (l.Tsize !== undefined) {
-          link.Tsize = l.Tsize
-        }
-        return link
-      })
-    }
-    if (node.Data) {
-      pbn.Data = node.Data
-    }
-    const serialized = encodeNode(pbn)
-    return bytes.coerce(serialized)
+  if (!pbl.Hash) {
+    throw new TypeError('Invalid DAG-PB form')
   }
 
-  const decode = (bytes) => {
-    const pbn = decodeNode(bytes)
-
-    const node = {}
-
-    if (pbn.Data) {
-      node.Data = pbn.Data
-    }
-
-    if (pbn.Links) {
-      node.Links = pbn.Links.map((l) => {
-        const link = {}
-        try {
-          link.Hash = new CID(l.Hash)
-        } catch (e) {}
-        if (!link.Hash) {
-          throw new Error('Invalid Hash field found in link, expected CID')
-        }
-        if (l.Name !== undefined) {
-          link.Name = l.Name
-        }
-        if (l.Tsize !== undefined) {
-          link.Tsize = l.Tsize
-        }
-        return link
-      })
-    }
-
-    return node
+  if (typeof link.Name === 'string') {
+    pbl.Name = link.Name
   }
 
-  return { encode, decode, validate, prepare, code, name }
+  if (typeof link.Tsize === 'number') {
+    pbl.Tsize = link.Tsize
+  }
+
+  return pbl
 }
 
-export default create
+function prepare (node) {
+  if (node instanceof Uint8Array || typeof node === 'string') {
+    node = { Data: node }
+  }
+
+  if (typeof node !== 'object' || Array.isArray(node)) {
+    throw new TypeError('Invalid DAG-PB form')
+  }
+
+  const pbn = {}
+
+  if (node.Data) {
+    if (typeof node.Data === 'string') {
+      pbn.Data = textEncoder.encode(node.Data)
+    } else if (node.Data instanceof Uint8Array) {
+      pbn.Data = node.Data
+    }
+  }
+
+  if (node.Links && Array.isArray(node.Links) && node.Links.length) {
+    pbn.Links = node.Links.map(asLink)
+    pbn.Links.sort(linkComparator)
+  } else {
+    pbn.Links = []
+  }
+
+  return pbn
+}
+
+function validate (node) {
+  /*
+  type PBLink struct {
+    Hash optional Link
+    Name optional String
+    Tsize optional Int
+  }
+
+  type PBNode struct {
+    Links [PBLink]
+    Data optional Bytes
+  }
+  */
+  if (!node || typeof node !== 'object' || Array.isArray(node)) {
+    throw new TypeError('Invalid DAG-PB form')
+  }
+
+  if (!hasOnlyProperties(node, pbNodeProperties)) {
+    throw new TypeError('Invalid DAG-PB form (extraneous properties)')
+  }
+
+  if (node.Data !== undefined && !(node.Data instanceof Uint8Array)) {
+    throw new TypeError('Invalid DAG-PB form (Data must be a Uint8Array)')
+  }
+
+  if (!Array.isArray(node.Links)) {
+    throw new TypeError('Invalid DAG-PB form (Links must be an array)')
+  }
+
+  for (let i = 0; i < node.Links.length; i++) {
+    const link = node.Links[i]
+    if (!link || typeof link !== 'object' || Array.isArray(link)) {
+      throw new TypeError('Invalid DAG-PB form (bad link object)')
+    }
+
+    if (!hasOnlyProperties(link, pbLinkProperties)) {
+      throw new TypeError('Invalid DAG-PB form (extraneous properties on link object)')
+    }
+
+    if (!link.Hash) {
+      throw new TypeError('Invalid DAG-PB form (link must have a Hash)')
+    }
+
+    if (link.Hash.asCID !== link.Hash) {
+      throw new TypeError('Invalid DAG-PB form (link Hash must be a CID)')
+    }
+
+    if (link.Name !== undefined && typeof link.Name !== 'string') {
+      throw new TypeError('Invalid DAG-PB form (link Name must be a string)')
+    }
+
+    if (link.Tsize !== undefined && (typeof link.Tsize !== 'number' || link.Tsize % 1 !== 0)) {
+      throw new TypeError('Invalid DAG-PB form (link Tsize must be an integer)')
+    }
+
+    if (i > 0 && linkComparator(link, node.Links[i - 1]) === -1) {
+      throw new TypeError('Invalid DAG-PB form (links must be sorted by Name bytes)')
+    }
+  }
+}
+
+function encode (node) {
+  validate(node)
+
+  const pbn = {}
+  if (node.Links) {
+    pbn.Links = node.Links.map((l) => {
+      const link = {}
+      if (l.Hash) {
+        link.Hash = l.Hash.bytes // cid -> bytes
+      }
+      if (l.Name !== undefined) {
+        link.Name = l.Name
+      }
+      if (l.Tsize !== undefined) {
+        link.Tsize = l.Tsize
+      }
+      return link
+    })
+  }
+  if (node.Data) {
+    pbn.Data = node.Data
+  }
+
+  return encodeNode(pbn)
+}
+
+function decode (bytes) {
+  const pbn = decodeNode(bytes)
+
+  const node = {}
+
+  if (pbn.Data) {
+    node.Data = pbn.Data
+  }
+
+  if (pbn.Links) {
+    node.Links = pbn.Links.map((l) => {
+      const link = {}
+      try {
+        link.Hash = CID.decode(l.Hash)
+      } catch (e) {}
+      if (!link.Hash) {
+        throw new Error('Invalid Hash field found in link, expected CID')
+      }
+      if (l.Name !== undefined) {
+        link.Name = l.Name
+      }
+      if (l.Tsize !== undefined) {
+        link.Tsize = l.Tsize
+      }
+      return link
+    })
+  }
+
+  return node
+}
+
+export default codec({ name, code, encode, decode })
+export { prepare, validate }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "type": "git",
     "url": "https://github.com/ipld/js-dag-pb.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "multiformats": "^4.0.0"
+  },
   "devDependencies": {
     "c8": "^7.3.1",
     "chai": "^4.2.0",
@@ -29,7 +31,6 @@
     "hundreds": "0.0.8",
     "ipjs": "^3.2.0",
     "mocha": "^8.1.3",
-    "multiformats": "^3.0.3",
     "polendina": "^1.1.0",
     "standard": "^14.3.4"
   }

--- a/test/test-compat.js
+++ b/test/test-compat.js
@@ -5,7 +5,7 @@
 import chai from 'chai'
 import { bytes } from 'multiformats'
 import CID from 'multiformats/cid'
-import dagPB from '@ipld/dag-pb'
+import { encode, decode } from '@ipld/dag-pb'
 import encodeNode from '../pb-encode.js'
 import decodeNode from '../pb-decode.js'
 
@@ -15,9 +15,9 @@ const { assert } = chai
 const acid = CID.decode(Uint8Array.from([1, 85, 0, 5, 0, 1, 2, 3, 4]))
 
 function verifyRoundTrip (testCase, bypass) {
-  const actualBytes = (bypass ? encodeNode : dagPB.encode)(testCase.node)
+  const actualBytes = (bypass ? encodeNode : encode)(testCase.node)
   assert.strictEqual(bytes.toHex(actualBytes), testCase.expectedBytes)
-  const roundTripNode = (bypass ? decodeNode : dagPB.decode)(actualBytes)
+  const roundTripNode = (bypass ? decodeNode : decode)(actualBytes)
   if (roundTripNode.Data) {
     roundTripNode.Data = bytes.toHex(roundTripNode.Data)
   }
@@ -139,7 +139,7 @@ describe('Compatibility', () => {
     // the failure is on the way in _and_ out, so we have to bypass encode & decode
     verifyRoundTrip(testCase, true)
     // don't bypass decode and check the bad CID test there
-    assert.throws(() => dagPB.decode(bytes.fromHex(testCase.expectedBytes)), /CID/)
+    assert.throws(() => decode(bytes.fromHex(testCase.expectedBytes)), /CID/)
   })
 
   it('Links Hash some', () => {

--- a/test/test-edges.js
+++ b/test/test-edges.js
@@ -1,11 +1,10 @@
 /* eslint-env mocha */
 
 import chai from 'chai'
+import { bytes } from 'multiformats'
 import encodeNode from '../pb-encode.js'
 import decodeNode from '../pb-decode.js'
-import multiformats from 'multiformats/basics'
 
-const { bytes } = multiformats
 const { assert } = chai
 const acidBytes = Uint8Array.from([1, 85, 0, 5, 0, 1, 2, 3, 4])
 

--- a/test/test-forms.js
+++ b/test/test-forms.js
@@ -2,7 +2,7 @@
 
 import chai from 'chai'
 import CID from 'multiformats/cid'
-import dagPB, { validate } from '@ipld/dag-pb'
+import { encode, validate } from '@ipld/dag-pb'
 
 const { assert } = chai
 
@@ -12,7 +12,7 @@ describe('Forms (Data Model)', () => {
   it('validate good forms', () => {
     const doesntThrow = (good) => {
       validate(good)
-      const byts = dagPB.encode(good)
+      const byts = encode(good)
       assert.instanceOf(byts, Uint8Array)
     }
 
@@ -40,7 +40,7 @@ describe('Forms (Data Model)', () => {
   it('validate fails bad forms', () => {
     const throws = (bad) => {
       assert.throws(() => validate(bad))
-      assert.throws(() => dagPB.encode(bad))
+      assert.throws(() => encode(bad))
     }
 
     for (const bad of [true, false, null, 0, 101, -101, 'blip', [], Infinity, Symbol.for('boop'), Uint8Array.from([1, 2, 3])]) {

--- a/test/test-forms.js
+++ b/test/test-forms.js
@@ -1,24 +1,18 @@
 /* eslint-env mocha */
 
 import chai from 'chai'
-import dagPB from '@ipld/dag-pb'
-import multiformats from 'multiformats/basics'
+import CID from 'multiformats/cid'
+import dagPB, { validate } from '@ipld/dag-pb'
 
 const { assert } = chai
 
-const { multicodec } = multiformats
-multicodec.add(dagPB)
-
-const encode = (v) => multicodec.encode(v, 'dag-pb')
-const { validate } = dagPB(multiformats)
-
-const acid = multiformats.CID.from('bafkqabiaaebagba')
+const acid = CID.parse('bafkqabiaaebagba')
 
 describe('Forms (Data Model)', () => {
   it('validate good forms', () => {
     const doesntThrow = (good) => {
       validate(good)
-      const byts = encode(good)
+      const byts = dagPB.encode(good)
       assert.instanceOf(byts, Uint8Array)
     }
 
@@ -46,7 +40,7 @@ describe('Forms (Data Model)', () => {
   it('validate fails bad forms', () => {
     const throws = (bad) => {
       assert.throws(() => validate(bad))
-      assert.throws(() => encode(bad))
+      assert.throws(() => dagPB.encode(bad))
     }
 
     for (const bad of [true, false, null, 0, 101, -101, 'blip', [], Infinity, Symbol.for('boop'), Uint8Array.from([1, 2, 3])]) {

--- a/test/test-pb.js
+++ b/test/test-pb.js
@@ -1,13 +1,10 @@
 /* eslint-env mocha */
 
 import chai from 'chai'
-// import encodeNode from '../pb-encode.js'
+import { bytes } from 'multiformats'
 import decodeNode from '../pb-decode.js'
-import multiformats from 'multiformats/basics'
 
-const { bytes } = multiformats
 const { assert } = chai
-// const acidBytes = Uint8Array.from([1, 85, 0, 5, 0, 1, 2, 3, 4])
 
 describe('Protobuf format', () => {
   describe('PBNode', () => {


### PR DESCRIPTION
@Gozala @mikeal could I get some :eyes: on this, conversion to the new js-multiformats.

Some feedback:

* The loss of `CID.from()` is a bit sad, I could throw Uint8Arrays and strings at it and it would figure it out. Now I need to be explicit. That's not so bad though, explicitness is a good thing.
* I don't have a `Block` to show off in the example, I assume that will come, but I'm also not sure what to show off as an example here, maybe the low-level form is OK?