### PR TITLE
bare export, no multiformats.codec() wrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An implementation of the [DAG-PB spec](https://github.com/ipld/specs/blob/master
 ```js
 import CID from 'multiformats/cid'
 import { sha256 } from 'multiformats/hashes/sha2'
-import dagPB from '@ipld/dag-pb'
+import * as dagPB from '@ipld/dag-pb'
 
 async function run () {
   const bytes = dagPB.encode({

--- a/example.js
+++ b/example.js
@@ -1,6 +1,6 @@
 import CID from 'multiformats/cid'
 import { sha256 } from 'multiformats/hashes/sha2'
-import dagPB from '@ipld/dag-pb'
+import * as dagPB from '@ipld/dag-pb'
 
 async function run () {
   const bytes = dagPB.encode({

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-import { codec } from 'multiformats/codecs/codec'
 import CID from 'multiformats/cid'
 import decodeNode from './pb-decode.js'
 import encodeNode from './pb-encode.js'
@@ -232,5 +231,4 @@ function decode (bytes) {
   return node
 }
 
-export default codec({ name, code, encode, decode })
-export { prepare, validate }
+export { name, code, encode, decode, prepare, validate }

--- a/test/test-compat.js
+++ b/test/test-compat.js
@@ -5,7 +5,7 @@
 import chai from 'chai'
 import { bytes } from 'multiformats'
 import CID from 'multiformats/cid'
-import dagPB from '@ipld/dag-pb'
+import { encode, decode } from '@ipld/dag-pb'
 import encodeNode from '../pb-encode.js'
 import decodeNode from '../pb-decode.js'
 
@@ -15,9 +15,9 @@ const { assert } = chai
 const acid = CID.decode(Uint8Array.from([1, 85, 0, 5, 0, 1, 2, 3, 4]))
 
 function verifyRoundTrip (testCase, bypass) {
-  const actualBytes = (bypass ? encodeNode : dagPB.encode)(testCase.node)
+  const actualBytes = (bypass ? encodeNode : encode)(testCase.node)
   assert.strictEqual(bytes.toHex(actualBytes), testCase.expectedBytes)
-  const roundTripNode = (bypass ? decodeNode : dagPB.decode)(actualBytes)
+  const roundTripNode = (bypass ? decodeNode : decode)(actualBytes)
   if (roundTripNode.Data) {
     roundTripNode.Data = bytes.toHex(roundTripNode.Data)
   }
@@ -139,7 +139,7 @@ describe('Compatibility', () => {
     // the failure is on the way in _and_ out, so we have to bypass encode & decode
     verifyRoundTrip(testCase, true)
     // don't bypass decode and check the bad CID test there
-    assert.throws(() => dagPB.decode(bytes.fromHex(testCase.expectedBytes)), /CID/)
+    assert.throws(() => decode(bytes.fromHex(testCase.expectedBytes)), /CID/)
   })
 
   it('Links Hash some', () => {

--- a/test/test-forms.js
+++ b/test/test-forms.js
@@ -2,7 +2,7 @@
 
 import chai from 'chai'
 import CID from 'multiformats/cid'
-import dagPB, { validate } from '@ipld/dag-pb'
+import { encode, validate } from '@ipld/dag-pb'
 
 const { assert } = chai
 
@@ -12,7 +12,7 @@ describe('Forms (Data Model)', () => {
   it('validate good forms', () => {
     const doesntThrow = (good) => {
       validate(good)
-      const byts = dagPB.encode(good)
+      const byts = encode(good)
       assert.instanceOf(byts, Uint8Array)
     }
 
@@ -40,7 +40,7 @@ describe('Forms (Data Model)', () => {
   it('validate fails bad forms', () => {
     const throws = (bad) => {
       assert.throws(() => validate(bad))
-      assert.throws(() => dagPB.encode(bad))
+      assert.throws(() => encode(bad))
     }
 
     for (const bad of [true, false, null, 0, 101, -101, 'blip', [], Infinity, Symbol.for('boop'), Uint8Array.from([1, 2, 3])]) {


### PR DESCRIPTION
In this variation of #3 we don't wrap in `multiformats.codec()` but just export `{ encode, decode, name, code, validate, prepare }`. That can be passed as a bundle into `multiformats.codec()` by an upstream user, but you can also use them independently, along with the additional non-standard `validate()` and `prepare()`. The choices for imports are, as in the example.js `import * as dagPB from '@ipld/dag-pb'` and then use `dagPB.encode()` etc. as if it was already wrapped in a `codec()` but you also get `dagPB.validate()` and `dagPB.prepare()`. The type is pulling them out individually as in example-prepare.js `import { prepare } from '@ipld/dag-pb'`. Which is kind of nice.

We still need to pull in `multiformats` as a dependency for the CID powers internally.