### PR TITLE
fix: type exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,15 +3,17 @@ import { decodeNode } from './pb-decode.js'
 import { encodeNode } from './pb-encode.js'
 
 /**
- * @template {number} Code
  * @template T
- * @typedef {import('multiformats/codecs/interface').BlockCodec<Code, T>} BlockCodec
+ * @typedef {import('multiformats/codecs/interface').ByteView<T>} ByteView
  */
 
 /**
  * @typedef {import('./interface').PBLink} PBLink
  * @typedef {import('./interface').PBNode} PBNode
  */
+
+export const name = 'dag-pb'
+export const code = 0x70
 
 const pbNodeProperties = ['Data', 'Links']
 const pbLinkProperties = ['Hash', 'Name', 'Tsize']
@@ -210,9 +212,9 @@ export function validate (node) {
 
 /**
  * @param {PBNode} node
- * @returns {Uint8Array}
+ * @returns {ByteView<PBNode>}
  */
-function _encode (node) {
+export function encode (node) {
   validate(node)
 
   const pbn = {}
@@ -239,10 +241,10 @@ function _encode (node) {
 }
 
 /**
- * @param {Uint8Array} bytes
+ * @param {ByteView<PBNode>} bytes
  * @returns {PBNode}
  */
-function _decode (bytes) {
+export function decode (bytes) {
   const pbn = decodeNode(bytes)
 
   const node = {}
@@ -271,14 +273,4 @@ function _decode (bytes) {
   }
 
   return node
-}
-
-/**
- * @type {BlockCodec<0x70, PBNode>}
- */
-export const { name, code, decode, encode } = {
-  name: 'dag-pb',
-  code: 0x70,
-  encode: _encode,
-  decode: _decode
 }

--- a/test/ts-use/package.json
+++ b/test/ts-use/package.json
@@ -6,6 +6,6 @@
     "multiformats": "file:../../node_modules/multiformats"
   },
   "scripts": {
-    "test": "npm install && npx -p typescript tsc && node src/main.js"
+    "test": "npm install && npm_config_yes=true npx -p typescript tsc && node src/main.js"
   }
 }

--- a/test/ts-use/src/main.ts
+++ b/test/ts-use/src/main.ts
@@ -8,11 +8,11 @@ const exampleNode:PBNode = { Data: Uint8Array.from([0, 1, 2, 3, 4]), Links: [] }
 const exampleBytes = [0x0a, 5, 0, 1, 2, 3, 4]
 
 const main = () => {
-  // make sure we have a full CodecFeature
-  useCodecFeature(dagPB)
+  // make sure we have a full codec
+  useCodec(dagPB)
 }
 
-function useCodecFeature (codec: BlockCodec<0x70, any>) {
+function useCodec (codec: BlockCodec<0x70, any>) {
   // use only as a BlockEncoder
   useEncoder(codec)
 

--- a/test/ts-use/tsconfig.json
+++ b/test/ts-use/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "moduleResolution": "node",
     "noImplicitAny": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "incremental": true
   }
 }


### PR DESCRIPTION
@gozala I'm going to need your help to verify this one, the types it now generates are:

```typescript
/**
 * @param {any} node
 * @returns {PBNode}
 */
export function prepare(node: any): PBNode;
/**
 * @param {PBNode} node
 */
export function validate(node: PBNode): void;
/**
 * @param {PBNode} node
 * @returns {ByteView<PBNode>}
 */
export function encode(node: PBNode): ByteView<PBNode>;
/**
 * @param {ByteView<PBNode>} bytes
 * @returns {PBNode}
 */
export function decode(bytes: ByteView<PBNode>): PBNode;
/**
 * @template T
 * @typedef {import('multiformats/codecs/interface').ByteView<T>} ByteView
 */
/**
 * @typedef {import('./interface').PBLink} PBLink
 * @typedef {import('./interface').PBNode} PBNode
 */
export const name: "dag-pb";
export const code: 112;
export type ByteView<T> = import('multiformats/codecs/interface').ByteView<T>;
export type PBLink = import('./interface').PBLink;
export type PBNode = import('./interface').PBNode;
```

that looks right to me, and my ts-use, which is now more strict, is OK with it. The unnecessary annotations around the function exports are mildly annoying and they'd go away if I just used the `export const fn = () => {}` pattern rather than `export function` but I prefer top-level functions to be called `function` so I'm ok living with this.