### PR TITLE
fix: size>maxuint32 calculation bug

### DIFF
--- a/src/pb-encode.js
+++ b/src/pb-encode.js
@@ -179,7 +179,7 @@ function sov (x) {
 function len64 (x) {
   let n = 0
   if (x >= maxInt32) {
-    x /= maxInt32
+    x = Math.floor(x / maxInt32)
     n = 32
   }
   if (x >= (1 << 16)) {

--- a/test/test-edges.js
+++ b/test/test-edges.js
@@ -45,4 +45,13 @@ describe('Edge cases', () => {
       encodeNode({ Links: [{ Hash: acidBytes, Name: 'yoik', Tsize: -1 }], Data: new Uint8Array(0) })
     }, /negative/)
   })
+
+  it('encode tsize >=uint32', () => {
+    const node = {
+      Links: [{ Hash: acidBytes, Name: 'big.bin', Tsize: 6779297111 }],
+      Data: new Uint8Array([8, 1])
+    }
+    const encoded = encodeNode(node)
+    assert.deepEqual(decodeNode(encoded), node)
+  })
 })


### PR DESCRIPTION
Fixes: https://github.com/ipfs-shipyard/nft.storage/issues/217

This case hit a very awkward edge that's not already tested in the code that pre-calculates how large a block needs to be in order to pre-allocate prior to encoding into it.