### PR TITLE
fix: add support for node16 module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "author": "Rod <rod@vagg.org> (http://r.va.gg/)",
   "license": "(Apache-2.0 AND MIT)",
   "exports": {
+    "types": "./types/src/index.d.ts",
     "import": "./src/index.js"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes module resolution with node16 ts configuration
see: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing