### PR TITLE
fix: update import paths to include extension

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,8 @@ import { prepare, validate, createNode, createLink } from './util.js'
  */
 
 /**
- * @typedef {import('./interface').PBLink} PBLink
- * @typedef {import('./interface').PBNode} PBNode
+ * @typedef {import('./interface.js').PBLink} PBLink
+ * @typedef {import('./interface.js').PBNode} PBNode
  */
 
 export const name = 'dag-pb'

--- a/src/pb-decode.js
+++ b/src/pb-decode.js
@@ -1,11 +1,11 @@
 const textDecoder = new TextDecoder()
 
 /**
- * @typedef {import('./interface').RawPBLink} RawPBLink
+ * @typedef {import('./interface.js').RawPBLink} RawPBLink
  */
 
 /**
- * @typedef {import('./interface').RawPBNode} RawPBNode
+ * @typedef {import('./interface.js').RawPBNode} RawPBNode
  */
 
 /**

--- a/src/pb-encode.js
+++ b/src/pb-encode.js
@@ -3,11 +3,11 @@ const maxInt32 = 2 ** 32
 const maxUInt32 = 2 ** 31
 
 /**
- * @typedef {import('./interface').RawPBLink} RawPBLink
+ * @typedef {import('./interface.js').RawPBLink} RawPBLink
  */
 
 /**
- * @typedef {import('./interface').RawPBNode} RawPBNode
+ * @typedef {import('./interface.js').RawPBNode} RawPBNode
  */
 
 // the encoders work backward from the end of the bytes array

--- a/src/util.js
+++ b/src/util.js
@@ -1,8 +1,8 @@
 import { CID } from 'multiformats/cid'
 
 /**
- * @typedef {import('./interface').PBLink} PBLink
- * @typedef {import('./interface').PBNode} PBNode
+ * @typedef {import('./interface.js').PBLink} PBLink
+ * @typedef {import('./interface.js').PBNode} PBNode
  */
 
 const pbNodeProperties = ['Data', 'Links']


### PR DESCRIPTION
The import path must include the extension when publishing ESM as otherwise the module loader doesn't know how to find the file.

Fixes errors like:

```
Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an
extension to the import path.
````

This is a weakness of JSDoc types.

Refs: https://github.com/multiformats/js-multiformats/issues/249