### PR TITLE
feat: support decoding ArrayBuffers

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "dep-check": "aegir dep-check -i @ipld/dag-pb"
   },
   "dependencies": {
-    "multiformats": "^13.0.0"
+    "multiformats": "^13.1.0"
   },
   "devDependencies": {
     "aegir": "^42.1.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,16 @@
 import { CID } from 'multiformats/cid'
 import { decodeNode } from './pb-decode.js'
 import { encodeNode } from './pb-encode.js'
-import { prepare, validate, createNode, createLink } from './util.js'
+import { prepare, validate, createNode, createLink, toByteView } from './util.js'
 
 /**
  * @template T
  * @typedef {import('multiformats/codecs/interface').ByteView<T>} ByteView
+ */
+
+/**
+ * @template T
+ * @typedef {import('multiformats/codecs/interface').ArrayBufferView<T>} ArrayBufferView
  */
 
 /**
@@ -47,11 +52,12 @@ export function encode (node) {
 }
 
 /**
- * @param {ByteView<PBNode>} bytes
+ * @param {ByteView<PBNode> | ArrayBufferView<PBNode>} bytes
  * @returns {PBNode}
  */
 export function decode (bytes) {
-  const pbn = decodeNode(bytes)
+  const buf = toByteView(bytes)
+  const pbn = decodeNode(buf)
 
   const node = {}
 

--- a/src/util.js
+++ b/src/util.js
@@ -5,6 +5,16 @@ import { CID } from 'multiformats/cid'
  * @typedef {import('./interface.js').PBNode} PBNode
  */
 
+/**
+ * @template T
+ * @typedef {import('multiformats/codecs/interface').ByteView<T>} ByteView
+ */
+
+/**
+ * @template T
+ * @typedef {import('multiformats/codecs/interface').ArrayBufferView<T>} ArrayBufferView
+ */
+
 const pbNodeProperties = ['Data', 'Links']
 const pbLinkProperties = ['Hash', 'Name', 'Tsize']
 
@@ -230,4 +240,17 @@ export function createNode (data, links = []) {
  */
 export function createLink (name, size, cid) {
   return asLink({ Hash: cid, Name: name, Tsize: size })
+}
+
+/**
+ * @template T
+ * @param {ByteView<T> | ArrayBufferView<T>} buf
+ * @returns {ByteView<T>}
+ */
+export function toByteView (buf) {
+  if (buf instanceof ArrayBuffer) {
+    return new Uint8Array(buf, 0, buf.byteLength)
+  }
+
+  return buf
 }

--- a/test/test-basics.spec.js
+++ b/test/test-basics.spec.js
@@ -44,6 +44,17 @@ describe('Basics', () => {
     assert.deepEqual(node.Data, data)
   })
 
+  it('prepare & encode a node with data using an ArrayBuffer', () => {
+    const data = Uint8Array.from([0, 1, 2, 3, 4])
+    const prepared = prepare({ Data: data })
+    assert.deepEqual(prepared, { Data: data, Links: [] })
+    const result = encode(prepared)
+    assert.instanceOf(result, Uint8Array)
+
+    const node = decode(result.buffer)
+    assert.deepEqual(node.Data, data)
+  })
+
   it('prepare & encode a node with links', () => {
     const links = [
       { Hash: CID.parse('QmWDtUQj38YLW8v3q4A6LwPn4vYKEbuKWpgSm6bjKW6Xfe') }

--- a/test/ts-use/src/main.ts
+++ b/test/ts-use/src/main.ts
@@ -19,6 +19,9 @@ function useCodec (codec: BlockCodec<0x70, any>) {
   // use only as a BlockDecoder
   useDecoder(codec)
 
+  // use with ArrayBuffer input type
+  useDecoderWithArrayBuffer(codec)
+
   // use as a full BlockCodec which does both BlockEncoder & BlockDecoder
   useBlockCodec(codec)
 }
@@ -33,6 +36,12 @@ function useEncoder<Codec extends number> (encoder: BlockEncoder<Codec, PBNode>)
 function useDecoder<Codec extends number> (decoder: BlockDecoder<Codec, Uint8Array>) {
   deepStrictEqual(decoder.code, 0x70)
   deepStrictEqual(decoder.decode(Uint8Array.from(exampleBytes)), exampleNode)
+  console.log('[TS] ✓ { decoder: BlockDecoder }')
+}
+
+function useDecoderWithArrayBuffer<Codec extends number> (decoder: BlockDecoder<Codec, Uint8Array>) {
+  deepStrictEqual(decoder.code, 0x70)
+  deepStrictEqual(decoder.decode(Uint8Array.from(exampleBytes).buffer), exampleNode)
   console.log('[TS] ✓ { decoder: BlockDecoder }')
 }
 


### PR DESCRIPTION
Expands supported input types to include `ArrayBuffer`s to make it easiser for users to use modules like `fetch` that don't return `Uint8Array`s.